### PR TITLE
Add invisible-playwright (open-source anti-detect browser)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ Useless:
 * [MarketerBrowser](https://www.marketerbrowser.com/) - can't even switch user-agent without detection
 
 A bit old [article on how anti-detect browsers can be detected](https://cpa.rip/stati/antidetect-palivo/). Example from the article: `if( Object.getOwnPropertyNames(navigator)[0] ) alert('fake parameters detected');`
-  
+
+* [invisible-playwright](https://github.com/feder-cr/invisible_playwright) - Patched Firefox 150 + Playwright wrapper, MIT licensed, self-hosted. Spoofing at the C++ level (no JS injection).
+
 # Detection tests
 
 Everything:


### PR DESCRIPTION
Open-source patched Firefox 150 with Playwright integration. Different angle from the commercial entries already listed: self-hosted, no SaaS, MIT for the wrapper plus MPL-2.0 patches against mozilla-central.

The C++ patches that go into the binary are in a companion repo: https://github.com/feder-cr/invisible-firefox