### PR TITLE
Add firefox-stealth (C++ patches for source-level anti-detect)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ Not recommended:
 More tools can be found at https://github.com/kkoooqq/fakebrowser  
 
 # Anti-detect libs
+* [firefox-stealth](https://github.com/feder-cr/firefox-stealth) - 15 C++ patches against mozilla-central (Firefox 150.0.1) that change fingerprint at the source level (Canvas, WebGL, Fonts, Audio, WebRTC, Timezone). MPL-2.0.
+
 
 [Privacy Manager](https://www.ivanovation.ro/modules/) - 12 modules to change fingerprint of your computer.
 


### PR DESCRIPTION
15 .patch files against mozilla-central at SourceStamp 094f3362dc that turn vanilla Firefox 150 into the binary distributed with the invisible-playwright wrapper. README.md documents each patch (Canvas 2D, GPU/WebGL, Fonts, Audio, WebRTC, Timezone, DevTools detection, SOCKS5 auth, etc).

Repo: https://github.com/feder-cr/firefox-stealth